### PR TITLE
Change ErrorCode parameter from string to integer

### DIFF
--- a/Source/Public/Get-ErrorDetail.ps1
+++ b/Source/Public/Get-ErrorDetail.ps1
@@ -26,7 +26,7 @@ Function Get-ErrorDetail
     [alias("err")]
     Param(
         [Parameter(ValueFromPipeline = $true)] 
-        [String] $ErrorCode
+        [int32] $ErrorCode
     )
 
     Begin


### PR DESCRIPTION
This solves #2 as Powershell converts 0x643 to 1603 (and all other hex values to integer).